### PR TITLE
Upgraded to use laravel 5.6 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/support": "^5.5",
+        "illuminate/support": "^5.6",
         "signifly/shopify-php-sdk": "0.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "^7.0",
         "orchestra/testbench": "^3.5"
     },
     "autoload": {


### PR DESCRIPTION
Updated composer-based dependencies: illuminate/support ^5.5 -> ^5.6 and phpunit/phpunit ^6.2 -> ^7.0.