### PR TITLE
fix: create correct redirect cursor

### DIFF
--- a/src/REST/Actions/ManagesOnlineStore.php
+++ b/src/REST/Actions/ManagesOnlineStore.php
@@ -25,7 +25,7 @@ trait ManagesOnlineStore
 
     public function paginateRedirects(array $params = []): Cursor
     {
-        return $this->cursor($this->getOrders($params));
+        return $this->cursor($this->getRedirects($params));
     }
 
     public function getRedirects(array $params = []): Collection


### PR DESCRIPTION
I forgot to call `getRedirects` instead of `getOrder`. Added test case that would have caught this.