### PR TITLE
fix: change http methods of two order methods

### DIFF
--- a/src/REST/Actions/ManagesOrders.php
+++ b/src/REST/Actions/ManagesOrders.php
@@ -52,7 +52,7 @@ trait ManagesOrders
 
     public function closeOrder($orderId): OrderResource
     {
-        $response = $this->get("orders/{$orderId}/close.json");
+        $response = $this->post("orders/{$orderId}/close.json");
 
         return new OrderResource($response['order'], $this);
     }
@@ -66,7 +66,7 @@ trait ManagesOrders
 
     public function cancelOrder($orderId): OrderResource
     {
-        $response = $this->get("orders/{$orderId}/cancel.json");
+        $response = $this->post("orders/{$orderId}/cancel.json");
 
         return new OrderResource($response['order'], $this);
     }


### PR DESCRIPTION
Hi,

I am using this package for a web app using shopify api with laravel, and it worked perfectly (thanks to those who have participated in the project).

But I found an error when trying to cancel or close orders, and reviewing the code I found that in those two methods are using HTTP GET methods when in the [shopify documentation](https://shopify.dev/api/admin-rest/2021-10/resources/order#top) these methods should be HTTP POST methods.

So this pull request fixes this error.

### Examples of the change

```php
# Before

public function closeOrder($orderId): OrderResource
{
    $response = $this->get("orders/{$orderId}/close.json");

    return new OrderResource($response['order'], $this);
}

```

```php
# After

public function closeOrder($orderId): OrderResource
{
    $response = $this->post("orders/{$orderId}/close.json");

    return new OrderResource($response['order'], $this);
}

```

I hope this pull request is useful.