### PR TITLE
[PHP 8.1] Add ReturnTypeWillChange attributes for ArrayAccess

### DIFF
--- a/src/REST/Resources/ApiResource.php
+++ b/src/REST/Resources/ApiResource.php
@@ -73,6 +73,7 @@ class ApiResource implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->attributes);
@@ -84,6 +85,7 @@ class ApiResource implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getAttribute($offset);
@@ -96,6 +98,7 @@ class ApiResource implements ArrayAccess, Arrayable
      * @param  mixed  $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         return $this->setAttribute($offset, $value);
@@ -107,6 +110,7 @@ class ApiResource implements ArrayAccess, Arrayable
      * @param  mixed  $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);


### PR DESCRIPTION
Hi there,

First, thanks for the great package and adding support for Laravel 9!

This PR adds the `ReturnTypeWillChange` attribute to the `ApiResource` class that implements `ArrayAccess`

In PHP 8.1 there is a deprecation notice for implementations of ArrayAccess that are not compatible with the return type. Other than that, everything works great with PHP 8.1. (Edit: I updated the testing workflow in #31)

```php
PHP Deprecated:  Return type of Signifly\Shopify\REST\Resources\ApiResource::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice 
```