### PR TITLE
Add testing workflow for PHP 8.1 and Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer config --global --auth http-basic.repo.packagist.com token ${{ secrets.COMPOSER_TOKEN }}
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 7.4, 8.0 ]
-        laravel: [ 8.* ]
+        php: [ 7.4, 8.0, 8.1 ]
+        laravel: [ 8.*, 9.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 8.*
-            testbench: ^6.15
+            testbench: ^6.24
+          - laravel: 9.*
+            testbench: 7.*
+        exclude:
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Hi there,

Follow-up to my previous PR. This adds Laravel 9, and PHP 8.1 to the actions testing workflow.

I kept PHP 7.4 although support has ended (and we only have 5 more months of security support for that version). If you'd like for me to drop PHP 7.4 all together, I'd be happy to update/submit a PR.

Thanks again!