### PR TITLE
fix: DraftOrder return type

### DIFF
--- a/src/REST/Actions/ManagesOrders.php
+++ b/src/REST/Actions/ManagesOrders.php
@@ -153,12 +153,12 @@ trait ManagesOrders
         return $this->getResources('draft_orders', $params);
     }
 
-    public function getDraftOrder($orderId): OrderResource
+    public function getDraftOrder($orderId): DraftOrderResource
     {
         return $this->getResource('draft_orders', $orderId);
     }
 
-    public function updateDraftOrder($orderId, $data): OrderResource
+    public function updateDraftOrder($orderId, $data): DraftOrderResource
     {
         return $this->updateResource('draft_orders', $orderId, $data);
     }


### PR DESCRIPTION
Hi,

I'm currently using this package within my Laravel app and working with DraftOrders.

I noticed that 2 methods were returning an incorrect type, this PR fixes that.

Thanks for your work on this package !