### PR TITLE
updates exception handling of WebhookController

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -8,8 +8,10 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Signifly\Shopify\Http\Middleware\ValidateWebhook;
 use Signifly\Shopify\Webhooks\Webhook;
+
 
 class WebhookController extends Controller
 {
@@ -27,6 +29,7 @@ class WebhookController extends Controller
 
             return new JsonResponse();
         } catch (Exception $e) {
+            Log::error($e->getMessage());
             return new Response('Error handling webhook', 500);
         }
     }


### PR DESCRIPTION
Exceptions are now logged when there is an issue handling a webhook.

I spent longer than really was necessary trying to figure out why a webhook wasn't working and returning a 500 error whilst the logs were empty.
might be useful for someone else down the line.