### PR TITLE
Added API Version to GraphQL

### DIFF
--- a/src/Shopify.php
+++ b/src/Shopify.php
@@ -74,7 +74,7 @@ class Shopify
 
     public function graphQl(): PendingRequest
     {
-        return Http::baseUrl("https://{$this->domain}/admin/api/graphql.json")
+        return Http::baseUrl("https://{$this->domain}/admin/api/{$this->apiVersion}/graphql.json")
             ->withHeaders(['X-Shopify-Access-Token' => $this->accessToken]);
     }
 


### PR DESCRIPTION
It seems PR #27 did not address adding api_version to GraphQL. Submitting this PR to resolve it. 