### PR TITLE
Update ManagesShopifyPayments.php

### DIFF
--- a/src/REST/Actions/ManagesShopifyPayments.php
+++ b/src/REST/Actions/ManagesShopifyPayments.php
@@ -13,9 +13,7 @@ trait ManagesShopifyPayments
 {
     public function getShopifyPaymentsBalance(): BalanceResource
     {
-        $response = $this->get('shopify_payments/balance');
-
-        return new BalanceResource($response['balance'], $this);
+        return $this->getResources('balance', $params, ['shopify_payments']);
     }
 
     public function getShopifyPaymentsDisputes(array $params = []): Collection


### PR DESCRIPTION
This method was not utilising the "getResources" builder. The endpoint should end with ".json" and it's basically not working