### PR TITLE
Fix adjustInventoryLevel response

### DIFF
--- a/src/REST/Actions/ManagesInventory.php
+++ b/src/REST/Actions/ManagesInventory.php
@@ -53,7 +53,7 @@ trait ManagesInventory
             'available_adjustment' => $availableAdjustment,
         ]);
 
-        return new ApiResource($response['inventory_level'], $this);
+        return new ApiResource($response->json(), $this);
     }
 
     public function connectInventoryLevel($inventoryItemId, $locationId, bool $relocate = false): ApiResource


### PR DESCRIPTION
When calling `$this->shopify->adjustInventoryLevel(...)`, I would get this error:

>    TypeError
>
 > Signifly\Shopify\REST\Resources\ApiResource::__construct(): Argument #1 ($attributes) must be of type array, null given, called in /app/musora-web-platform/vendor/signifly/laravel-shopify/src/REST/Actions/ManagesInventory.php on line 56

After looking into the response in the `adjustInventoryLevel` function, I found that there was no "inventory_level" value, and after a few trials, found that returning the `$response->json()` as the first parameter for the ApiResource seemed to create the expected results, based on looking at some other actions' responses. 

I expect this change (if it's accepted) should be applied to all other functions in this class that are returning `new ApiResource($response['inventory_level'], $this)`, but since I haven't yet had a need to call the other functions, I haven't tested these cases and left them for now.