### PR TITLE
Add optional responseKey to updateResource and fix updateCustomerAddress

### DIFF
--- a/src/REST/Actions/ManagesCustomers.php
+++ b/src/REST/Actions/ManagesCustomers.php
@@ -97,7 +97,7 @@ trait ManagesCustomers
 
     public function updateCustomerAddress($customerId, $addressId, $data): ApiResource
     {
-        return $this->updateResource('addresses', $addressId, $data, ['customers', $customerId]);
+        return $this->updateResource('addresses', $addressId, $data, ['customers', $customerId], 'customer_address');
     }
 
     public function deleteCustomerAddress($customerId, $addressId): void

--- a/src/Support/MakesHttpRequests.php
+++ b/src/Support/MakesHttpRequests.php
@@ -102,12 +102,16 @@ trait MakesHttpRequests
         return new $resourceClass($response[$key], $this);
     }
 
-    protected function updateResource(string $resource, $resourceId, array $data, array $uriPrefix = []): ApiResource
+    protected function updateResource(string $resource, $resourceId, array $data, array $uriPrefix = [], string $responseKey = null): ApiResource
     {
         $key = Str::singular($resource);
         $resourceClass = $this->resourceClassFor($resource);
 
         $response = $this->put(implode('/', [...$uriPrefix, "{$resource}/{$resourceId}.json"]), [$key => $data]);
+
+        if (! empty($responseKey)) {
+            $key = $responseKey;
+        }
 
         return new $resourceClass($response[$key], $this);
     }


### PR DESCRIPTION
When calling `$this->shopify->updateCustomerAddress(...)`, I would get this error:

>    Undefined array key "address"

As per the [docs](https://shopify.dev/docs/api/admin-rest/2023-04/resources/customer-address#put-customers-customer-id-addresses-address-id), the response has `customer_address` and not `address`, as the code was looking for. I spotted that the [createCustomerAddress](https://github.com/signifly/laravel-shopify/blob/master/src/REST/Actions/ManagesCustomers.php#L83) function, and subsequently the [createResource](https://github.com/signifly/laravel-shopify/blob/master/src/Support/MakesHttpRequests.php#L66) function made use of a specified response key of "customer_address". I simply applied the same logic for the update.