### PR TITLE
Update PHP version requirement to support PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.3",
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
         "illuminate/http": "^8.0|^9.0|^10.0|^11.0",


### PR DESCRIPTION
Allow installations on PHP 8.3. Tested with a fresh Laravel 11.