### PR TITLE
Ensure errors property is an array

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace Signifly\Shopify\Exceptions;
 
+use Illuminate\Support\Arr;
 use Illuminate\Http\Client\Response;
 
 class Handler implements ErrorHandlerInterface
@@ -17,7 +18,7 @@ class Handler implements ErrorHandlerInterface
         }
 
         if ($response->status() === 422) {
-            throw new ValidationException($response->json('errors', []));
+            throw new ValidationException(Arr::wrap($response->json('errors', [])));
         }
 
         if ($response->status() === 404) {


### PR DESCRIPTION
Sometines Shopify sends an errors as a string and not as an array which is causing a TypeError with the `ValidationException`

```
Signifly\Shopify\Exceptions\ValidationException::__construct(): Argument #1 ($errors) must be of type array, string given
```

This PR is to ensure that the errors property is always an array